### PR TITLE
Allow Xbox controller notifications longer than expected length

### DIFF
--- a/src/XboxControllerElite2NotificationParser.cpp
+++ b/src/XboxControllerElite2NotificationParser.cpp
@@ -1,0 +1,80 @@
+#include "XboxControllerElite2NotificationParser.h"
+
+#define XBOX_CONTROLLER_INDEX_PROFILE 16
+#define XBOX_CONTROLLER_INDEX_PADDLES 18
+
+uint8_t XboxControllerElite2NotificationParser::update(uint8_t *data, size_t length)
+{
+    XboxControllerNotificationParser::update(data, length);
+    uint8_t btnBits;
+
+    if (length > XBOX_CONTROLLER_INDEX_PROFILE)
+    {
+        profile = data[XBOX_CONTROLLER_INDEX_PROFILE];
+    }
+    else
+    {
+        profile = 0;
+    }
+
+    if (length > XBOX_CONTROLLER_INDEX_PADDLES)
+    {
+        btnBits = data[XBOX_CONTROLLER_INDEX_PADDLES];
+        btnP1 = btnBits & 0b00000001;
+        btnP2 = btnBits & 0b00000010;
+        btnP3 = btnBits & 0b00000100;
+        btnP4 = btnBits & 0b00001000;
+    }
+    else
+    {
+        btnP1 = false;
+        btnP2 = false;
+        btnP3 = false;
+        btnP4 = false;
+    }
+    return 0;
+}
+
+String XboxControllerElite2NotificationParser::toString()
+{
+    String str = XboxControllerNotificationParser::toString();
+    str +=
+        "btnPaddle1: " + String(btnP1) + " " +
+        "btnPaddle2: " + String(btnP2) + " " +
+        "btnPaddle3: " + String(btnP3) + " " +
+        "btnPaddle4: " + String(btnP4) + "\n" +
+        "profile: " + String(profile) + "\n";
+    return str;
+}
+
+uint8_t XboxControllerElite2NotificationParser::toArr(uint8_t *data, size_t length)
+{
+    XboxControllerNotificationParser::toArr(data, length);
+
+    if (length > XBOX_CONTROLLER_INDEX_PROFILE)
+    {
+        data[XBOX_CONTROLLER_INDEX_PROFILE] = profile;
+    }
+
+    if (length > XBOX_CONTROLLER_INDEX_PADDLES)
+    {
+        uint8_t btnBits = 0;
+        if (btnP1)
+            btnBits |= 0b1 << 0;
+        if (btnP2)
+            btnBits |= 0b1 << 1;
+        if (btnP3)
+            btnBits |= 0b1 << 2;
+        if (btnP4)
+            btnBits |= 0b1 << 3;
+
+        data[XBOX_CONTROLLER_INDEX_PADDLES] = btnBits;
+    }
+    return 0;
+}
+
+XboxControllerElite2NotificationParser::XboxControllerElite2NotificationParser() : XboxControllerNotificationParser()
+{
+    btnP1 = btnP2 = btnP3 = btnP4 = 0;
+    profile = 0;
+}

--- a/src/XboxControllerElite2NotificationParser.h
+++ b/src/XboxControllerElite2NotificationParser.h
@@ -1,0 +1,17 @@
+#ifndef __XBOX_CONTROLLER_ELITE2_NOTIFICATION_PARSER_H__
+#define __XBOX_CONTROLLER_ELITE2_NOTIFICATION_PARSER_H__
+#include "XboxControllerNotificationParser.h"
+
+class XboxControllerElite2NotificationParser : public XboxControllerNotificationParser
+{
+private:
+public:
+    XboxControllerElite2NotificationParser();
+    uint8_t update(uint8_t *data, size_t length);
+    String toString();
+    uint8_t toArr(uint8_t *data, size_t length);
+    bool btnP1, btnP2, btnP3, btnP4;
+    uint8_t profile;
+};
+
+#endif

--- a/src/XboxControllerNotificationParser.cpp
+++ b/src/XboxControllerNotificationParser.cpp
@@ -4,8 +4,6 @@
 #define XBOX_CONTROLLER_INDEX_BUTTONS_MAIN 13
 #define XBOX_CONTROLLER_INDEX_BUTTONS_CENTER 14
 #define XBOX_CONTROLLER_INDEX_BUTTONS_SHARE 15
-#define XBOX_CONTROLLER_INDEX_PROFILE 16
-#define XBOX_CONTROLLER_INDEX_PADDLES 18
 
 XboxControllerNotificationParser::XboxControllerNotificationParser() {
   btnA = btnB = btnX = btnY = false;
@@ -44,29 +42,6 @@ uint8_t XboxControllerNotificationParser::update(uint8_t* data, size_t length) {
   btnDirRight = 2 <= btnBits && btnBits <= 4;
   btnDirDown = 4 <= btnBits && btnBits <= 6;
   btnDirLeft = 6 <= btnBits && btnBits <= 8;
-
-  if (length > XBOX_CONTROLLER_INDEX_PROFILE)
-  {
-    profile = data[XBOX_CONTROLLER_INDEX_PROFILE];
-  }
-  else{
-    profile = 0;
-  }
-
-  if (length > XBOX_CONTROLLER_INDEX_PADDLES)
-  {
-    btnBits = data[XBOX_CONTROLLER_INDEX_PADDLES];
-    btnP1 = btnBits & 0b00000001;
-    btnP2 = btnBits & 0b00000010;
-    btnP3 = btnBits & 0b00000100;
-    btnP4 = btnBits & 0b00001000;
-  }
-  else{
-    btnP1 = false;
-    btnP2 = false;
-    btnP3 = false;
-    btnP4 = false;
-  }
 
   joyLHori = (uint16_t)data[0] | ((uint16_t)data[1] << 8);
   joyLVert = (uint16_t)data[2] | ((uint16_t)data[3] << 8);
@@ -168,11 +143,6 @@ String XboxControllerNotificationParser::toString() {
     "btnDirRight: " + String(btnDirRight) + " " +
     "btnDirDown: " + String(btnDirDown) + " " +
     "btnDirLeft: " + String(btnDirLeft) + "\n"
-    "btnPaddle1: " + String(btnP1) + " "
-    "btnPaddle2: " + String(btnP2) + " "
-    "btnPaddle3: " + String(btnP3) + " "
-    "btnPaddle4: " + String(btnP4) + "\n"
-    "profile: " + String(profile) + "\n"
     "joyLHori: " + String(joyLHori) + "\n" +
     "joyLVert: " + String(joyLVert) + "\n" +
     "joyRHori: " + String(joyRHori) + "\n" +

--- a/src/XboxControllerNotificationParser.cpp
+++ b/src/XboxControllerNotificationParser.cpp
@@ -15,7 +15,7 @@ XboxControllerNotificationParser::XboxControllerNotificationParser() {
 }
 
 uint8_t XboxControllerNotificationParser::update(uint8_t* data, size_t length) {
-  if (length != expectedDataLen) {
+  if (length < expectedDataLen) {
     return XBOX_CONTROLLER_ERROR_INVALID_LENGTH;
   }
   uint8_t btnBits;

--- a/src/XboxControllerNotificationParser.cpp
+++ b/src/XboxControllerNotificationParser.cpp
@@ -4,6 +4,8 @@
 #define XBOX_CONTROLLER_INDEX_BUTTONS_MAIN 13
 #define XBOX_CONTROLLER_INDEX_BUTTONS_CENTER 14
 #define XBOX_CONTROLLER_INDEX_BUTTONS_SHARE 15
+#define XBOX_CONTROLLER_INDEX_PROFILE 16
+#define XBOX_CONTROLLER_INDEX_PADDLES 18
 
 XboxControllerNotificationParser::XboxControllerNotificationParser() {
   btnA = btnB = btnX = btnY = false;
@@ -42,6 +44,29 @@ uint8_t XboxControllerNotificationParser::update(uint8_t* data, size_t length) {
   btnDirRight = 2 <= btnBits && btnBits <= 4;
   btnDirDown = 4 <= btnBits && btnBits <= 6;
   btnDirLeft = 6 <= btnBits && btnBits <= 8;
+
+  if (length > XBOX_CONTROLLER_INDEX_PROFILE)
+  {
+    profile = data[XBOX_CONTROLLER_INDEX_PROFILE];
+  }
+  else{
+    profile = 0;
+  }
+
+  if (length > XBOX_CONTROLLER_INDEX_PADDLES)
+  {
+    btnBits = data[XBOX_CONTROLLER_INDEX_PADDLES];
+    btnP1 = btnBits & 0b00000001;
+    btnP2 = btnBits & 0b00000010;
+    btnP3 = btnBits & 0b00000100;
+    btnP4 = btnBits & 0b00001000;
+  }
+  else{
+    btnP1 = false;
+    btnP2 = false;
+    btnP3 = false;
+    btnP4 = false;
+  }
 
   joyLHori = (uint16_t)data[0] | ((uint16_t)data[1] << 8);
   joyLVert = (uint16_t)data[2] | ((uint16_t)data[3] << 8);
@@ -143,6 +168,11 @@ String XboxControllerNotificationParser::toString() {
     "btnDirRight: " + String(btnDirRight) + " " +
     "btnDirDown: " + String(btnDirDown) + " " +
     "btnDirLeft: " + String(btnDirLeft) + "\n"
+    "btnPaddle1: " + String(btnP1) + " "
+    "btnPaddle2: " + String(btnP2) + " "
+    "btnPaddle3: " + String(btnP3) + " "
+    "btnPaddle4: " + String(btnP4) + "\n"
+    "profile: " + String(profile) + "\n"
     "joyLHori: " + String(joyLHori) + "\n" +
     "joyLVert: " + String(joyLVert) + "\n" +
     "joyRHori: " + String(joyRHori) + "\n" +

--- a/src/XboxControllerNotificationParser.h
+++ b/src/XboxControllerNotificationParser.h
@@ -16,8 +16,6 @@ class XboxControllerNotificationParser {
   // button on joy stick
   bool btnLS, btnRS;
   bool btnDirUp, btnDirLeft, btnDirRight, btnDirDown;
-  bool btnP1, btnP2, btnP3, btnP4;
-  uint8_t profile;
   uint16_t joyLHori = maxJoy / 2;
   uint16_t joyLVert = maxJoy / 2;
   uint16_t joyRHori = maxJoy / 2;

--- a/src/XboxControllerNotificationParser.h
+++ b/src/XboxControllerNotificationParser.h
@@ -16,6 +16,8 @@ class XboxControllerNotificationParser {
   // button on joy stick
   bool btnLS, btnRS;
   bool btnDirUp, btnDirLeft, btnDirRight, btnDirDown;
+  bool btnP1, btnP2, btnP3, btnP4;
+  uint8_t profile;
   uint16_t joyLHori = maxJoy / 2;
   uint16_t joyLVert = maxJoy / 2;
   uint16_t joyRHori = maxJoy / 2;


### PR DESCRIPTION
## Description

The parser currently rejects Xbox controller notifications when the received data length is not exactly 16 bytes.

The Xbox Elite Series 2 can send 19-byte notifications, which causes the parser to reject the packet and prevents the controller state from being updated.

This change allows notifications with additional data by changing the length check from an exact match to a minimum length check.

### Change

```cpp
if (length < expectedDataLen) {
    return XBOX_CONTROLLER_ERROR_INVALID_LENGTH;
}
```

### Testing

Tested with an Xbox Elite Series 2 controller.

The 19-byte notifications are now accepted and the existing joystick, trigger, and button data can be parsed correctly.

Thank you.
